### PR TITLE
Adapt model and training for custom dataset

### DIFF
--- a/single_model.py
+++ b/single_model.py
@@ -1,0 +1,543 @@
+"""
+Standalone UNet model with drug-embedding conditioning for multiplex images.
+
+This script contains no external project imports. It embeds the necessary
+building blocks (normalizations, timestep embeddings, residual and attention
+blocks) and exposes a single class `UNetModel` that can be imported by a
+training script.
+
+Key adaptations for requested use:
+- Supports arbitrary input/output channels (default 42) for multiplex images
+  of size 256x256
+- Accepts a conditioning vector per-sample (e.g., BBBC drug embedding)
+  provided as `extra={"concat_conditioning": <tensor [B, condition_dim]>}`
+- Time conditioning enabled by default (standard diffusion usage)
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+import math
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+# -----------------------------
+# Minimal NN utilities
+# -----------------------------
+
+
+class GroupNorm32(nn.GroupNorm):
+    def forward(self, x):
+        return super().forward(x.float()).type(x.dtype)
+
+
+def conv_nd(dims, *args, **kwargs):
+    if dims == 1:
+        return nn.Conv1d(*args, **kwargs)
+    elif dims == 2:
+        return nn.Conv2d(*args, **kwargs)
+    elif dims == 3:
+        return nn.Conv3d(*args, **kwargs)
+    raise ValueError(f"unsupported dimensions: {dims}")
+
+
+def linear(*args, **kwargs):
+    return nn.Linear(*args, **kwargs)
+
+
+def avg_pool_nd(dims, *args, **kwargs):
+    if dims == 1:
+        return nn.AvgPool1d(*args, **kwargs)
+    elif dims == 2:
+        return nn.AvgPool2d(*args, **kwargs)
+    elif dims == 3:
+        return nn.AvgPool3d(*args, **kwargs)
+    raise ValueError(f"unsupported dimensions: {dims}")
+
+
+def zero_module(module):
+    for p in module.parameters():
+        p.detach().zero_()
+    return module
+
+
+def normalization(channels):
+    return GroupNorm32(32, channels)
+
+
+def timestep_embedding(timesteps, dim, max_period=10000):
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period) * torch.arange(start=0, end=half, dtype=torch.float32) / half
+    ).to(device=timesteps.device)
+    args = timesteps[:, None].float() * freqs[None]
+    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    if dim % 2:
+        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+    return embedding
+
+
+# -----------------------------
+# UNet components
+# -----------------------------
+
+
+class ConstantEmbedding(nn.Module):
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.embedding_table = nn.Parameter(torch.empty((1, out_channels)))
+        nn.init.uniform_(self.embedding_table, -(in_channels ** 0.5), in_channels ** 0.5)
+
+    def forward(self, emb):
+        return self.embedding_table.repeat(emb.shape[0], 1)
+
+
+class TimestepBlock(nn.Module):
+    def forward(self, x, emb):  # type: ignore[override]
+        raise NotImplementedError
+
+
+class TimestepEmbedSequential(nn.Sequential, TimestepBlock):
+    def forward(self, x, emb):  # type: ignore[override]
+        for layer in self:
+            if isinstance(layer, TimestepBlock):
+                x = layer(x, emb)
+            else:
+                x = layer(x)
+        return x
+
+
+class Upsample(nn.Module):
+    def __init__(self, channels, use_conv, dims=2, out_channels=None):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.dims = dims
+        if use_conv:
+            self.conv = conv_nd(dims, self.channels, self.out_channels, 3, padding=1)
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+        if self.dims == 3:
+            x = F.interpolate(x, (x.shape[2], x.shape[3] * 2, x.shape[4] * 2), mode="nearest")
+        else:
+            x = F.interpolate(x, scale_factor=2, mode="nearest")
+        if self.use_conv:
+            x = self.conv(x)
+        return x
+
+
+class Downsample(nn.Module):
+    def __init__(self, channels, use_conv, dims=2, out_channels=None):
+        super().__init__()
+        self.channels = channels
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.dims = dims
+        stride = 2 if dims != 3 else (1, 2, 2)
+        if use_conv:
+            self.op = conv_nd(dims, self.channels, self.out_channels, 3, stride=stride, padding=1)
+        else:
+            assert self.channels == self.out_channels
+            self.op = avg_pool_nd(dims, kernel_size=stride, stride=stride)
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+        return self.op(x)
+
+
+class ResBlock(TimestepBlock):
+    def __init__(
+        self,
+        channels,
+        emb_channels,
+        dropout,
+        out_channels=None,
+        use_conv=False,
+        use_scale_shift_norm=False,
+        dims=2,
+        use_checkpoint=False,
+        up=False,
+        down=False,
+        emb_off=False,
+    ):
+        super().__init__()
+        self.channels = channels
+        self.emb_channels = emb_channels
+        self.dropout = dropout
+        self.out_channels = out_channels or channels
+        self.use_conv = use_conv
+        self.use_checkpoint = use_checkpoint
+        self.use_scale_shift_norm = use_scale_shift_norm
+
+        self.in_layers = nn.Sequential(
+            normalization(channels),
+            nn.SiLU(),
+            conv_nd(dims, channels, self.out_channels, 3, padding=1),
+        )
+
+        self.updown = up or down
+
+        if up:
+            self.h_upd = Upsample(channels, False, dims)
+            self.x_upd = Upsample(channels, False, dims)
+        elif down:
+            self.h_upd = Downsample(channels, False, dims)
+            self.x_upd = Downsample(channels, False, dims)
+        else:
+            self.h_upd = self.x_upd = nn.Identity()
+
+        if emb_off:
+            self.emb_layers = ConstantEmbedding(
+                emb_channels,
+                2 * self.out_channels if use_scale_shift_norm else self.out_channels,
+            )
+        else:
+            self.emb_layers = nn.Sequential(
+                nn.SiLU(),
+                linear(
+                    emb_channels,
+                    2 * self.out_channels if use_scale_shift_norm else self.out_channels,
+                ),
+            )
+
+        self.out_layers = nn.Sequential(
+            normalization(self.out_channels),
+            nn.SiLU(),
+            nn.Dropout(p=dropout),
+            zero_module(conv_nd(dims, self.out_channels, self.out_channels, 3, padding=1)),
+        )
+
+        if self.out_channels == channels:
+            self.skip_connection = nn.Identity()
+        elif use_conv:
+            self.skip_connection = conv_nd(dims, channels, self.out_channels, 3, padding=1)
+        else:
+            self.skip_connection = conv_nd(dims, channels, self.out_channels, 1)
+
+    def forward(self, x, emb):  # type: ignore[override]
+        def _forward(x, emb):
+            if self.updown:
+                in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
+                h = in_rest(x)
+                h = self.h_upd(h)
+                x = self.x_upd(x)
+                h = in_conv(h)
+            else:
+                h = self.in_layers(x)
+            emb_out = self.emb_layers(emb).type(h.dtype)
+            while len(emb_out.shape) < len(h.shape):
+                emb_out = emb_out[..., None]
+            if self.use_scale_shift_norm:
+                out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
+                scale, shift = torch.chunk(emb_out, 2, dim=1)
+                h = out_norm(h) * (1 + scale) + shift
+                h = out_rest(h)
+            else:
+                h = h + emb_out
+                h = self.out_layers(h)
+            return self.skip_connection(x) + h
+
+        if self.use_checkpoint and self.training:
+            return torch.utils.checkpoint.checkpoint(_forward, x, emb)
+        else:
+            return _forward(x, emb)
+
+
+class QKVAttention(nn.Module):
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv):
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.chunk(3, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum(
+            "bct,bcs->bts",
+            (q * scale).view(bs * self.n_heads, ch, length),
+            (k * scale).view(bs * self.n_heads, ch, length),
+        )
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum("bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length))
+        return a.reshape(bs, -1, length)
+
+
+class AttentionBlock(nn.Module):
+    def __init__(
+        self,
+        channels,
+        num_heads=1,
+        num_head_channels=-1,
+        use_checkpoint=False,
+        use_new_attention_order=False,
+    ):
+        super().__init__()
+        self.channels = channels
+        if num_head_channels == -1:
+            self.num_heads = num_heads
+        else:
+            assert channels % num_head_channels == 0
+            self.num_heads = channels // num_head_channels
+        self.use_checkpoint = use_checkpoint
+        self.norm = normalization(channels)
+        self.qkv = conv_nd(1, channels, channels * 3, 1)
+        self.attention = QKVAttention(self.num_heads)
+        self.proj_out = zero_module(conv_nd(1, channels, channels, 1))
+
+    def forward(self, x):
+        def _forward(x):
+            b, c, *spatial = x.shape
+            x_ = x.reshape(b, c, -1)
+            qkv = self.qkv(self.norm(x_))
+            h = self.attention(qkv)
+            h = self.proj_out(h)
+            return (x_ + h).reshape(b, c, *spatial)
+
+        if self.use_checkpoint and self.training:
+            return torch.utils.checkpoint.checkpoint(_forward, x)
+        else:
+            return _forward(x)
+
+
+@dataclass(eq=False)
+class UNetModel(nn.Module):
+    in_channels: int = 42
+    model_channels: int = 128
+    out_channels: int = 42
+    num_res_blocks: int = 4
+    attention_resolutions: Tuple[int] = (2,)
+    dropout: float = 0.1
+    channel_mult: Tuple[int] = (2, 2, 2)
+    conv_resample: bool = True
+    dims: int = 2
+    num_classes: Optional[int] = None
+    use_checkpoint: bool = False
+    num_heads: int = 1
+    num_head_channels: int = -1
+    num_heads_upsample: int = -1
+    use_scale_shift_norm: bool = True
+    resblock_updown: bool = False
+    use_new_attention_order: bool = True
+    with_fourier_features: bool = False
+    ignore_time: bool = False
+    input_projection: bool = True
+    condition_dim: int = 1024
+
+    def __post_init__(self):
+        super().__init__()
+
+        if self.with_fourier_features:
+            self.in_channels += 12
+
+        if self.num_heads_upsample == -1:
+            self.num_heads_upsample = self.num_heads
+
+        self.time_embed_dim = self.model_channels * 4
+
+        self.mol_embed_transform = nn.Linear(self.condition_dim, self.time_embed_dim)
+        if self.ignore_time:
+            self.time_embed = lambda x: torch.zeros(
+                x.shape[0], self.time_embed_dim, device=x.device, dtype=x.dtype
+            )
+        else:
+            self.time_embed = nn.Sequential(
+                linear(self.model_channels, self.time_embed_dim),
+                nn.SiLU(),
+                linear(self.time_embed_dim, self.time_embed_dim),
+            )
+
+        if self.num_classes is not None:
+            self.label_emb = nn.Embedding(self.num_classes + 1, self.time_embed_dim, padding_idx=self.num_classes)
+
+        ch = input_ch = int(self.channel_mult[0] * self.model_channels)
+        if self.input_projection:
+            self.input_blocks = nn.ModuleList([TimestepEmbedSequential(conv_nd(self.dims, self.in_channels, ch, 3, padding=1))])
+        else:
+            self.input_blocks = nn.ModuleList([TimestepEmbedSequential(torch.nn.Identity())])
+        self._feature_size = ch
+        input_block_chans = [ch]
+        ds = 1
+        for level, mult in enumerate(self.channel_mult):
+            for _ in range(self.num_res_blocks):
+                layers = [
+                    ResBlock(
+                        ch,
+                        self.time_embed_dim,
+                        self.dropout,
+                        out_channels=int(mult * self.model_channels),
+                        dims=self.dims,
+                        use_checkpoint=self.use_checkpoint,
+                        use_scale_shift_norm=self.use_scale_shift_norm,
+                        emb_off=self.ignore_time and self.num_classes is None,
+                    )
+                ]
+                ch = int(mult * self.model_channels)
+                if ds in self.attention_resolutions:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=self.use_checkpoint,
+                            num_heads=self.num_heads,
+                            num_head_channels=self.num_head_channels,
+                            use_new_attention_order=self.use_new_attention_order,
+                        )
+                    )
+                self.input_blocks.append(TimestepEmbedSequential(*layers))
+                self._feature_size += ch
+                input_block_chans.append(ch)
+            if level != len(self.channel_mult) - 1:
+                out_ch = ch
+                self.input_blocks.append(
+                    TimestepEmbedSequential(
+                        ResBlock(
+                            ch,
+                            self.time_embed_dim,
+                            self.dropout,
+                            out_channels=out_ch,
+                            dims=self.dims,
+                            use_checkpoint=self.use_checkpoint,
+                            use_scale_shift_norm=self.use_scale_shift_norm,
+                            down=True,
+                            emb_off=self.ignore_time and self.num_classes is None,
+                        )
+                        if self.resblock_updown
+                        else Downsample(ch, self.conv_resample, dims=self.dims, out_channels=out_ch)
+                    )
+                )
+                ch = out_ch
+                input_block_chans.append(ch)
+                ds *= 2
+                self._feature_size += ch
+
+        self.middle_block = TimestepEmbedSequential(
+            ResBlock(
+                ch,
+                self.time_embed_dim,
+                self.dropout,
+                dims=self.dims,
+                use_checkpoint=self.use_checkpoint,
+                use_scale_shift_norm=self.use_scale_shift_norm,
+                emb_off=self.ignore_time and self.num_classes is None,
+            ),
+            AttentionBlock(
+                ch,
+                use_checkpoint=self.use_checkpoint,
+                num_heads=self.num_heads,
+                num_head_channels=self.num_head_channels,
+                use_new_attention_order=self.use_new_attention_order,
+            ),
+            ResBlock(
+                ch,
+                self.time_embed_dim,
+                self.dropout,
+                dims=self.dims,
+                use_checkpoint=self.use_checkpoint,
+                use_scale_shift_norm=self.use_scale_shift_norm,
+                emb_off=self.ignore_time and self.num_classes is None,
+            ),
+        )
+        self._feature_size += ch
+
+        self.output_blocks = nn.ModuleList([])
+        for level, mult in list(enumerate(self.channel_mult))[::-1]:
+            for i in range(self.num_res_blocks + 1):
+                ich = input_block_chans.pop()
+                layers = [
+                    ResBlock(
+                        ch + ich,
+                        self.time_embed_dim,
+                        self.dropout,
+                        out_channels=int(self.model_channels * mult),
+                        dims=self.dims,
+                        use_checkpoint=self.use_checkpoint,
+                        use_scale_shift_norm=self.use_scale_shift_norm,
+                        emb_off=self.ignore_time and self.num_classes is None,
+                    )
+                ]
+                ch = int(self.model_channels * mult)
+                if ds in self.attention_resolutions:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=self.use_checkpoint,
+                            num_heads=self.num_heads_upsample,
+                            num_head_channels=self.num_head_channels,
+                            use_new_attention_order=self.use_new_attention_order,
+                        )
+                    )
+                if level and i == self.num_res_blocks:
+                    out_ch = ch
+                    layers.append(
+                        ResBlock(
+                            ch,
+                            self.time_embed_dim,
+                            self.dropout,
+                            out_channels=out_ch,
+                            dims=self.dims,
+                            use_checkpoint=self.use_checkpoint,
+                            use_scale_shift_norm=self.use_scale_shift_norm,
+                            up=True,
+                            emb_off=self.ignore_time and self.num_classes is None,
+                        )
+                        if self.resblock_updown
+                        else Upsample(ch, self.conv_resample, dims=self.dims, out_channels=out_ch)
+                    )
+                    ds //= 2
+                self.output_blocks.append(TimestepEmbedSequential(*layers))
+                self._feature_size += ch
+
+        self.out = nn.Sequential(
+            normalization(ch),
+            nn.SiLU(),
+            zero_module(conv_nd(self.dims, input_ch, self.out_channels, 3, padding=1)),
+        )
+
+    def forward(self, x, timesteps, extra):
+        if self.with_fourier_features:
+            z_f = base2_fourier_features(x, start=6, stop=8, step=1)
+            x = torch.cat([x, z_f], dim=1)
+
+        hs = []
+        emb = self.time_embed(timestep_embedding(timesteps, self.model_channels).to(x))
+
+        if self.ignore_time:
+            emb = emb * 0.0
+
+        if self.num_classes is not None and "label" in extra:
+            y = extra["label"]
+            assert y.shape == x.shape[:1]
+            emb = emb + self.label_emb(y)
+
+        h = x
+        if "concat_conditioning" in extra:
+            mol_embedding = self.mol_embed_transform(extra["concat_conditioning"])  # [B, time_embed_dim]
+            emb = emb + mol_embedding
+
+        for module in self.input_blocks:
+            h = module(h, emb)
+            hs.append(h)
+        h = self.middle_block(h, emb)
+        for module in self.output_blocks:
+            h = torch.cat([h, hs.pop()], dim=1)
+            h = module(h, emb)
+        h = h.type(x.dtype)
+        result = self.out(h)
+        return result
+
+
+def base2_fourier_features(inputs: torch.Tensor, start: int = 0, stop: int = 8, step: int = 1) -> torch.Tensor:
+    freqs = torch.arange(start, stop, step, device=inputs.device, dtype=inputs.dtype)
+    w = 2.0 ** freqs * 2 * np.pi
+    w = torch.tile(w[None, :], (1, inputs.size(1)))
+    h = torch.repeat_interleave(inputs, len(freqs), dim=1)
+    h = w[:, :, None, None] * h
+    h = torch.cat([torch.sin(h), torch.cos(h)], dim=1)
+    return h
+

--- a/train_custom.py
+++ b/train_custom.py
@@ -1,0 +1,239 @@
+"""
+Single-file training script for UNet on custom multiplex images (42x256x256)
+with BBBC-style drug embeddings.
+
+Requirements:
+- PyTorch
+
+Usage example:
+python train_custom.py \
+  --images_root /path/to/images \
+  --index_csv /path/to/index.csv \
+  --embeddings_csv /path/to/drug_embeddings.csv \
+  --epochs 100 --batch_size 8 --lr 2e-4
+
+Assumptions:
+- The index CSV has at least columns: SAMPLE_KEY, CPD_NAME
+- Images are stored as .npy or .pt tensors under images_root with filenames
+  matching SAMPLE_KEY and shape [42, 256, 256]
+- embeddings_csv is a table indexed by CPD_NAME with embedding dim 1024
+"""
+
+import os
+import math
+import time
+import argparse
+import random
+import pandas as pd
+import numpy as np
+from typing import Dict, Any
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.utils.data import Dataset, DataLoader
+
+from single_model import UNetModel
+
+
+def set_seed(seed: int):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+class MultiplexDataset(Dataset):
+    def __init__(self, index_df: pd.DataFrame, images_root: str, emb_table: pd.DataFrame):
+        super().__init__()
+        self.df = index_df.reset_index(drop=True)
+        self.images_root = images_root
+        self.emb_table = emb_table
+        assert "SAMPLE_KEY" in self.df.columns, "index CSV must include SAMPLE_KEY"
+        assert "CPD_NAME" in self.df.columns, "index CSV must include CPD_NAME"
+
+    def __len__(self):
+        return len(self.df)
+
+    def _load_image(self, key: str) -> torch.Tensor:
+        # Tries .npy first then .pt
+        npy_path = os.path.join(self.images_root, f"{key}.npy")
+        pt_path = os.path.join(self.images_root, f"{key}.pt")
+        if os.path.isfile(npy_path):
+            arr = np.load(npy_path)
+            x = torch.tensor(arr, dtype=torch.float32)
+        elif os.path.isfile(pt_path):
+            x = torch.load(pt_path)
+            if not isinstance(x, torch.Tensor):
+                x = torch.tensor(x, dtype=torch.float32)
+        else:
+            raise FileNotFoundError(f"Missing image file for key {key} in {self.images_root}")
+        assert x.ndim == 3 and x.shape[0] == 42 and x.shape[1] == 256 and x.shape[2] == 256, (
+            f"Expected image shape [42,256,256], got {tuple(x.shape)} for key {key}")
+        return x
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        row = self.df.iloc[idx]
+        key = row["SAMPLE_KEY"]
+        drug = row["CPD_NAME"]
+        x = self._load_image(key)  # [42,256,256]
+        emb = self.emb_table.loc[drug].values.astype(np.float32)
+        emb = torch.tensor(emb, dtype=torch.float32)
+        return {"x": x, "cond": emb}
+
+
+def make_dataloaders(index_csv: str, images_root: str, embeddings_csv: str, batch_size: int, num_workers: int, val_split: float = 0.1):
+    df = pd.read_csv(index_csv)
+    assert "SAMPLE_KEY" in df.columns and "CPD_NAME" in df.columns
+    emb = pd.read_csv(embeddings_csv, index_col=0)
+    # Ensure CPD_NAME alignment
+    missing = set(df["CPD_NAME"]) - set(emb.index)
+    if missing:
+        raise ValueError(f"Missing embeddings for {len(missing)} compounds, e.g. {list(missing)[:5]}")
+
+    # Simple split
+    perm = np.random.permutation(len(df))
+    n_val = int(len(df) * val_split)
+    val_idx = perm[:n_val]
+    tr_idx = perm[n_val:]
+    tr_ds = MultiplexDataset(df.iloc[tr_idx], images_root, emb)
+    val_ds = MultiplexDataset(df.iloc[val_idx], images_root, emb)
+    tr_dl = DataLoader(tr_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers, pin_memory=True, drop_last=True)
+    val_dl = DataLoader(val_ds, batch_size=batch_size, shuffle=False, num_workers=num_workers, pin_memory=True)
+    return tr_dl, val_dl
+
+
+# Simple DDPM-like noise schedule helpers
+def get_beta_schedule(T: int, beta_start=1e-4, beta_end=0.02):
+    return torch.linspace(beta_start, beta_end, T)
+
+
+def train(args):
+    device = torch.device("cuda" if torch.cuda.is_available() and not args.cpu else "cpu")
+    set_seed(args.seed)
+
+    train_loader, val_loader = make_dataloaders(
+        args.index_csv, args.images_root, args.embeddings_csv, args.batch_size, args.num_workers, args.val_split
+    )
+
+    model = UNetModel(
+        in_channels=42,
+        out_channels=42,
+        model_channels=args.model_channels,
+        num_res_blocks=args.num_res_blocks,
+        attention_resolutions=tuple(args.attn_res),
+        dropout=args.dropout,
+        channel_mult=tuple(args.channel_mult),
+        use_checkpoint=args.ckpt,
+        condition_dim=args.condition_dim,
+        use_scale_shift_norm=True,
+        use_new_attention_order=True,
+    ).to(device)
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr, weight_decay=args.wd)
+
+    # Diffusion setup
+    T = args.timesteps
+    betas = get_beta_schedule(T).to(device)
+    alphas = 1.0 - betas
+    alphas_cumprod = torch.cumprod(alphas, dim=0)
+
+    def q_sample(x0, t, noise):
+        a_bar = alphas_cumprod[t].view(-1, 1, 1, 1)
+        return torch.sqrt(a_bar) * x0 + torch.sqrt(1 - a_bar) * noise
+
+    scaler = torch.cuda.amp.GradScaler(enabled=args.amp and device.type == "cuda")
+
+    best_val = float("inf")
+    global_step = 0
+
+    for epoch in range(1, args.epochs + 1):
+        model.train()
+        running = 0.0
+        for batch in train_loader:
+            x = batch["x"].to(device)
+            cond = batch["cond"].to(device)
+            B = x.shape[0]
+            t = torch.randint(0, T, (B,), device=device, dtype=torch.long)
+            noise = torch.randn_like(x)
+            x_t = q_sample(x, t, noise)
+            extra = {"concat_conditioning": cond}
+
+            optimizer.zero_grad(set_to_none=True)
+            with torch.cuda.amp.autocast(enabled=args.amp and device.type == "cuda"):
+                pred = model(x_t, t, extra)
+                loss = F.mse_loss(pred, noise)
+            scaler.scale(loss).backward()
+            scaler.step(optimizer)
+            scaler.update()
+
+            running += loss.item()
+            global_step += 1
+        train_loss = running / max(1, len(train_loader))
+
+        # Validation (predict noise on a fixed t)
+        model.eval()
+        with torch.no_grad():
+            val_running = 0.0
+            for batch in val_loader:
+                x = batch["x"].to(device)
+                cond = batch["cond"].to(device)
+                B = x.shape[0]
+                t = torch.randint(0, T, (B,), device=device, dtype=torch.long)
+                noise = torch.randn_like(x)
+                x_t = q_sample(x, t, noise)
+                extra = {"concat_conditioning": cond}
+                pred = model(x_t, t, extra)
+                val_loss = F.mse_loss(pred, noise)
+                val_running += val_loss.item()
+            val_loss = val_running / max(1, len(val_loader))
+
+        is_best = val_loss < best_val
+        best_val = min(best_val, val_loss)
+
+        print(f"Epoch {epoch:03d} | train {train_loss:.4f} | val {val_loss:.4f} | best {best_val:.4f}")
+
+        if (epoch % args.save_every == 0) or is_best:
+            os.makedirs(args.out_dir, exist_ok=True)
+            ckpt = {
+                "epoch": epoch,
+                "model": model.state_dict(),
+                "optimizer": optimizer.state_dict(),
+                "args": vars(args),
+                "best_val": best_val,
+            }
+            name = "best.pt" if is_best else f"epoch_{epoch}.pt"
+            torch.save(ckpt, os.path.join(args.out_dir, name))
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--images_root", type=str, required=True)
+    p.add_argument("--index_csv", type=str, required=True)
+    p.add_argument("--embeddings_csv", type=str, required=True)
+    p.add_argument("--out_dir", type=str, default="./checkpoints")
+    p.add_argument("--epochs", type=int, default=100)
+    p.add_argument("--batch_size", type=int, default=8)
+    p.add_argument("--lr", type=float, default=2e-4)
+    p.add_argument("--wd", type=float, default=0.0)
+    p.add_argument("--num_workers", type=int, default=4)
+    p.add_argument("--val_split", type=float, default=0.1)
+    p.add_argument("--timesteps", type=int, default=1000)
+    p.add_argument("--model_channels", type=int, default=128)
+    p.add_argument("--num_res_blocks", type=int, default=4)
+    p.add_argument("--attn_res", type=int, nargs="+", default=[2])
+    p.add_argument("--channel_mult", type=int, nargs="+", default=[2, 2, 2])
+    p.add_argument("--dropout", type=float, default=0.1)
+    p.add_argument("--ckpt", action="store_true")
+    p.add_argument("--condition_dim", type=int, default=1024)
+    p.add_argument("--cpu", action="store_true")
+    p.add_argument("--seed", type=int, default=1337)
+    p.add_argument("--save_every", type=int, default=10)
+    p.add_argument("--amp", action="store_true")
+    return p.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    train(args)
+


### PR DESCRIPTION
Add a standalone UNet model and a training script to support custom 42-channel 256x256 multiplex images with 1024-d drug embeddings.

---
<a href="https://cursor.com/background-agent?bcId=bc-c059fed5-1930-4748-bc69-b4d034e3cb36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c059fed5-1930-4748-bc69-b4d034e3cb36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

